### PR TITLE
Potential fix for code scanning alert no. 34: Missing rate limiting

### DIFF
--- a/nodejs/Azure/Graph/package.json
+++ b/nodejs/Azure/Graph/package.json
@@ -9,6 +9,7 @@
         "express": "^5.0.0",
         "node18": "^1.0.0",
         "os": "^0.1.2",
-        "properties-reader": "^2.2.0"
+        "properties-reader": "^2.2.0",
+        "express-rate-limit": "^7.5.0"
     }
 }

--- a/nodejs/Azure/Graph/src/restapi.js
+++ b/nodejs/Azure/Graph/src/restapi.js
@@ -4,8 +4,14 @@ const fs = require('fs')
 const azure = require('./azure.js')
 const bodyParser = require('body-parser')
 const PropertiesReader = require('properties-reader')
+const RateLimit = require('express-rate-limit');
 
 /* eslint-disable no-use-before-define */
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 function processRequest (svrapp) {
   // Standard functions...
   svrapp.get('/', (request, response) => {
@@ -49,6 +55,7 @@ function main () {
       extended: true
     })
   )
+  svrapp.use(limiter);
   svrapp.use(
     express.static(
       // path.join(__dirname, "scripts")


### PR DESCRIPTION
Potential fix for [https://github.com/tpayne/lang-examples/security/code-scanning/34](https://github.com/tpayne/lang-examples/security/code-scanning/34)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `restapi.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
